### PR TITLE
Update calendar indicator sizing utility

### DIFF
--- a/src/app/dashboard/requests/Calendar.tsx
+++ b/src/app/dashboard/requests/Calendar.tsx
@@ -162,7 +162,7 @@ export default function Calendar({
               {hasRequests && (
                 <span
                   className={clsx(
-                    "absolute bottom-3 w-1.5 h-1.5 rounded-full",
+                    "absolute bottom-3 size-1.5 rounded-full",
                     isSelected ? "bg-white" : "bg-green-500"
                   )}
                 />


### PR DESCRIPTION
## Summary
- use the `size-1.5` utility for the calendar request indicator dot to match design conventions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cf816af8b4832da7a2900aada1fbf2