### PR TITLE
Adjust shrink utility class in RowCard

### DIFF
--- a/src/components/RowCard.tsx
+++ b/src/components/RowCard.tsx
@@ -157,7 +157,7 @@ function Actions({
   "title" | "subtitle" | "image" | "leading" | "contentBox" | "titleClassName"
 >) {
   return (
-    <div className="flex items-center gap-x-3 ml-auto flex-shrink-0">
+    <div className="flex items-center gap-x-3 ml-auto shrink-0">
       <div className="flex items-center gap-x-3 flex-shrink-0">
         {buttonLabel && (
           <Button


### PR DESCRIPTION
## Summary
- update the outer actions container to use the Tailwind `shrink-0` utility instead of the deprecated `flex-shrink-0`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf816432a8832dbd8ba868c7df336d