### PR TITLE
Update RowCard avatar sizing utility

### DIFF
--- a/src/components/RowCard.tsx
+++ b/src/components/RowCard.tsx
@@ -95,7 +95,7 @@ function Leading({
       {leading && <div className={showAvatar ? "mr-3" : ""}>{leading}</div>}
 
       {showAvatar && (
-        <Avatar className="w-10 h-10 border border-gray-200/60 bg-gray-100">
+        <Avatar className="size-10 border border-gray-200/60 bg-gray-100">
           {image ? (
             <AvatarImage
               src={image}


### PR DESCRIPTION
## Summary
- switch the RowCard avatar component to use the `size-10` utility instead of separate width and height classes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cf815d3d6c832da2aaf5721e26bd1d