### PR TITLE
Remove redundant border class from InfoCard alert

### DIFF
--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -15,7 +15,7 @@ export function InfoCard({
   onClick,
 }: InfoCardProps) {
   return (
-    <Alert className="flex items-center justify-between rounded-xl bg-gray-200/80 border border-none text-sm">
+    <Alert className="flex items-center justify-between rounded-xl bg-gray-200/80 border-0 text-sm">
       {/* Left side: icon + text */}
       <div className="flex items-center space-x-2">
         <Info className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- update the InfoCard alert styling to drop the redundant border class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cf813d3478832da23cd3e4429f63f2