### PR TITLE
Request data prefetch and ephemeral drafts

### DIFF
--- a/src/app/dashboard/requests/Calendar.tsx
+++ b/src/app/dashboard/requests/Calendar.tsx
@@ -128,9 +128,15 @@ export default function Calendar({
           }
 
           const list = requestsByDate?.[cell.key] ?? [];
-          const hasActive = list.some((r) => r.status === "active");
-          const hasDraft = list.some((r) => r.status === "draft");
-          const hasRequests = list.length > 0;
+
+          // only keep active requests and non-ephemeral drafts
+          const visibleList = list.filter(
+            (r) => r.status !== "draft" || r.ephemeral !== true
+          );
+
+          const hasActive = visibleList.some((r) => r.status === "active");
+          const hasDraft = visibleList.some((r) => r.status === "draft");
+          const hasRequests = visibleList.length > 0;
 
           return (
             <button

--- a/src/app/dashboard/requests/DataSection.tsx
+++ b/src/app/dashboard/requests/DataSection.tsx
@@ -129,9 +129,9 @@ export default function DataSection({
         </ToggleGroup>
       </div>
 
-      {selectedView === "requests" && sortedRequests.length > 0 ? (
+      {selectedView === "requests" && visibleRequests.length > 0 ? (
         <div className="space-y-3">
-          {sortedRequests.map((req) => (
+          {visibleRequests.map((req) => (
             <RowCard
               key={req.id}
               contentBox={req.prompt || "No prompt provided"}

--- a/src/app/dashboard/requests/DataSection.tsx
+++ b/src/app/dashboard/requests/DataSection.tsx
@@ -53,8 +53,11 @@ export default function DataSection({
     };
   }, [selectedDate, requestsByDate]);
 
-  const sortedRequests = useMemo(() => {
-    return [...dataCards];
+  const visibleRequests = useMemo(() => {
+    // Keep all active requests, only keep drafts that are NOT ephemeral
+    return (dataCards ?? []).filter(
+      (req) => req.status !== "draft" || req.ephemeral !== true
+    );
   }, [dataCards]);
 
   if (!selectedDate) return null;

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -50,9 +50,10 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
     requestsByDate,
     ensureDraft,
     updateActive,
-    deleteRequest,
+
     subscribe,
-    requests,
+
+    maybeCleanupEphemeral,
   } = useRequestListStore();
 
   useEffect(() => {
@@ -87,18 +88,9 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
     return () => {
       if (!user?.uid || !nextRequestId) return;
       if (draftUsedRef.current) return;
-      const draft = requests[nextRequestId];
-      if (
-        draft &&
-        draft.status === "draft" &&
-        draft.ephemeral === true &&
-        !draft.prompt &&
-        !draft.scheduledDate
-      ) {
-        deleteRequest(user.uid, nextRequestId).catch(() => {});
-      }
+      maybeCleanupEphemeral(user.uid, nextRequestId).catch(() => {});
     };
-  }, [user?.uid, nextRequestId, requests, deleteRequest]);
+  }, [user?.uid, nextRequestId, maybeCleanupEphemeral]);
 
   if (loading) {
     return <LoadingScreen />;

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -89,6 +89,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
       if (
         draft &&
         draft.status === "draft" &&
+        draft.ephemeral === true &&
         !draft.prompt &&
         !draft.scheduledDate
       ) {

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -80,7 +80,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
     } catch (err) {
       console.error("RequestsClient: subscribe failed", err);
     }
-  }, [user?.uid, loading, subscribe]);
+  }, [user?.uid, loading, subscribe, ensureDraft, router]);
 
   // 🧹 Cleanup unused draft on unmount
   useEffect(() => {

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -25,6 +25,7 @@ export interface RequestItem {
   q2: string;
   q3: string;
   status: "draft" | "active";
+  ephemeral?: boolean;
 }
 
 export interface RequestOptions {
@@ -50,9 +51,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
     requestsByDate,
     ensureDraft,
     updateActive,
-
     subscribe,
-
     maybeCleanupEphemeral,
   } = useRequestListStore();
 

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   today,
   toDateKey,
@@ -43,6 +43,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
   const [selectedDate, setSelectedDate] = useState<Date | null>(initialDate);
   const [currentDate, setCurrentDate] = useState<Date>(initialDate);
   const [nextRequestId, setNextRequestId] = useState<string | null>(null);
+  const draftUsedRef = useRef(false);
 
   const { user, loading } = useAuth();
   const {
@@ -85,6 +86,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
   useEffect(() => {
     return () => {
       if (!user?.uid || !nextRequestId) return;
+      if (draftUsedRef.current) return;
       const draft = requests[nextRequestId];
       if (
         draft &&
@@ -130,6 +132,7 @@ export default function RequestsClient({ dateParam }: { dateParam?: string }) {
     try {
       router.prefetch(url);
     } catch {}
+    draftUsedRef.current = true;
     router.push(url);
   };
 

--- a/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
+++ b/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
@@ -120,6 +120,7 @@ export default function SetupClient({
     await updateActive(user.uid, requestId, {
       prompt: prompt ?? "",
       scheduledDate: scheduledDate ?? null,
+      ephemeral: false,
     });
 
     router.push(

--- a/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
+++ b/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
@@ -120,7 +120,6 @@ export default function SetupClient({
     await updateActive(user.uid, requestId, {
       prompt: prompt ?? "",
       scheduledDate: scheduledDate ?? null,
-      ephemeral: false,
     });
 
     router.push(

--- a/src/lib/models/request-admin.ts
+++ b/src/lib/models/request-admin.ts
@@ -22,6 +22,7 @@ type FirestoreRequestData = {
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
   submittedAt?: Timestamp;
+  ephemeral?: boolean;
 };
 
 export const requestReadConverterAdmin: FirestoreDataConverter<Request> = {
@@ -48,6 +49,7 @@ export const requestReadConverterAdmin: FirestoreDataConverter<Request> = {
       createdAt: d.createdAt ? d.createdAt.toDate() : null,
       updatedAt: d.updatedAt ? d.updatedAt.toDate() : null,
       submittedAt: d.submittedAt ? d.submittedAt.toDate() : null,
+      ephemeral: d.ephemeral ?? false,
     };
   },
 };

--- a/src/lib/models/request-client.ts
+++ b/src/lib/models/request-client.ts
@@ -22,6 +22,7 @@ type FirestoreRequestData = {
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
   submittedAt?: Timestamp;
+  ephemeral?: boolean;
 };
 
 export const requestReadConverterClient: FirestoreDataConverter<Request> = {
@@ -48,6 +49,7 @@ export const requestReadConverterClient: FirestoreDataConverter<Request> = {
       createdAt: d.createdAt ? d.createdAt.toDate() : null,
       updatedAt: d.updatedAt ? d.updatedAt.toDate() : null,
       submittedAt: d.submittedAt ? d.submittedAt.toDate() : null,
+      ephemeral: d.ephemeral ?? false,
     };
   },
 };

--- a/src/lib/models/request-types.ts
+++ b/src/lib/models/request-types.ts
@@ -9,6 +9,7 @@ export interface Request {
   createdAt: Date | null;
   updatedAt: Date | null;
   submittedAt?: Date | null;
+  ephemeral?: boolean;
 }
 
 // Shape for partial updates

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -31,6 +31,7 @@ interface WriteRequestClient {
   createdAt: FieldValue;
   updatedAt: FieldValue;
   submittedAt?: FieldValue;
+  ephemeral?: boolean;
 }
 
 // --- helpers ---
@@ -95,6 +96,7 @@ export async function ensureDraft(uid: string): Promise<string> {
   const q = query(
     col,
     where("status", "==", "draft"),
+    where("ephemeral", "==", true),
     orderBy("createdAt", "desc"),
     limit(1)
   );
@@ -116,6 +118,7 @@ export async function ensureDraft(uid: string): Promise<string> {
     scheduledDate: null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
+    ephemeral: true, // mark as system scratchpad
   };
   await setDoc(newRef, write, { merge: false });
   return newRef.id;

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -137,18 +137,23 @@ export async function updateActive(
 
   if ("prompt" in patch) {
     update.prompt = coalesceText(patch.prompt);
+    update.ephemeral = false;
   }
   if ("q1" in patch) {
     update.q1 = coalesceText(patch.q1);
+    update.ephemeral = false;
   }
   if ("q2" in patch) {
     update.q2 = coalesceText(patch.q2);
+    update.ephemeral = false;
   }
   if ("q3" in patch) {
     update.q3 = coalesceText(patch.q3);
+    update.ephemeral = false;
   }
   if ("scheduledDate" in patch) {
     update.scheduledDate = serializeScheduledDate(patch.scheduledDate ?? null);
+    update.ephemeral = false;
   }
 
   await updateDoc(ref, update);
@@ -158,6 +163,7 @@ export async function promoteToActive(uid: string, id: string) {
   await updateDoc(doc(db, "users", uid, "requests", id), {
     status: "active",
     updatedAt: serverTimestamp(),
+    ephemeral: false,
   });
 }
 

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -84,6 +84,7 @@ export async function createDraft(
     scheduledDate: serializeScheduledDate(data.scheduledDate ?? null),
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
+    ephemeral: true,
   };
   await setDoc(ref, write, { merge: false });
 }

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -153,7 +153,6 @@ export async function updateActive(
   }
   if ("scheduledDate" in patch) {
     update.scheduledDate = serializeScheduledDate(patch.scheduledDate ?? null);
-    update.ephemeral = false;
   }
 
   await updateDoc(ref, update);

--- a/src/lib/stores/useRequestStore.ts
+++ b/src/lib/stores/useRequestStore.ts
@@ -76,7 +76,9 @@ export const useRequestListStore = create<RequestListState>((set, get) => ({
   },
 
   drafts: () =>
-    Object.values(get().requests).filter((r) => r.status === "draft"),
+    Object.values(get().requests).filter(
+      (r) => r.status === "draft" && !r.ephemeral
+    ),
   actives: () =>
     Object.values(get().requests).filter((r) => r.status === "active"),
 

--- a/src/lib/stores/useRequestStore.ts
+++ b/src/lib/stores/useRequestStore.ts
@@ -61,6 +61,7 @@ interface RequestListState {
   promoteToActive: (uid: string, id: string) => Promise<void>;
   demoteToDraft: (uid: string, id: string) => Promise<void>;
   deleteRequest: (uid: string, id: string) => Promise<void>;
+  maybeCleanupEphemeral: (uid: string, id: string) => Promise<void>;
 }
 
 export const useRequestListStore = create<RequestListState>((set, get) => ({
@@ -182,5 +183,18 @@ export const useRequestListStore = create<RequestListState>((set, get) => ({
         requestsByDate: buildRequestsByDate(rest),
       };
     });
+  },
+
+  maybeCleanupEphemeral: async (uid, id) => {
+    const draft = get().requests[id];
+    if (
+      draft &&
+      draft.status === "draft" &&
+      draft.ephemeral === true &&
+      !draft.prompt &&
+      !draft.scheduledDate
+    ) {
+      await deleteRequest(uid, id);
+    }
   },
 }));

--- a/src/lib/stores/useRequestStore.ts
+++ b/src/lib/stores/useRequestStore.ts
@@ -10,6 +10,7 @@ import {
   promoteToActive,
   demoteToDraft,
   deleteRequest,
+  ensureDraft,
 } from "@/lib/services/requestService-client";
 
 import { toDateKey } from "@/lib/requestDates";
@@ -51,6 +52,7 @@ interface RequestListState {
     data?: Partial<Request>,
     id?: string
   ) => Promise<string>;
+  ensureDraft: (uid: string) => Promise<string>;
   updateActive: (
     uid: string,
     id: string,
@@ -96,6 +98,13 @@ export const useRequestListStore = create<RequestListState>((set, get) => ({
     const finalId = id ?? crypto.randomUUID();
     await createDraft(uid, finalId, data ?? {});
     return finalId;
+  },
+
+  ensureDraft: async (uid) => {
+    const id = await ensureDraft(uid);
+    // hydrate into local state so it's immediately available
+    await get().loadOne(uid, id);
+    return id;
   },
 
   updateActive: async (uid, id, data) => {


### PR DESCRIPTION
Main problem:
- when users clicked on "request data" from within an empty state
- it then a draft request would show up before the user navigates to the setup screen

Secondary problem: navigating to setup screen was slow

Main problem is now solved
Secondary problem is somewhat improved

What happens now is that the requests section creates a draft
Even before the user clicks on "request data"
-> means that the draft creation doesn't need to happen before navigating
-> improves the secondary problem

This pre-created draft is marked as ephemeral
And it only becomes non-ephemeral when the user writes to it
Key: adding a scheduledDate doesn't make non-ephemeral
Since non-ephemeral is often done by the UI and not the user
-> this allows the requests UI to not show these ephemeral drafts at all
-> which solves the main problem completely

Finally, the requests screen now also prefetches the setup screen
Which means it's pre-loading the UI
-> improves the secondary problem

These changes required changing the services/node/models which are in /lib
The data model now accounts for ephemeral drafts
There's now a service which pre-creates drafts
And existing services now switch ephemeral to false when appropriate
