### PR TITLE
Loading between setup and questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-toggle": "^1.1.10",
@@ -3085,6 +3086,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toggle": "^1.1.10",

--- a/src/app/dashboard/requests/RequestsClient.tsx
+++ b/src/app/dashboard/requests/RequestsClient.tsx
@@ -15,7 +15,7 @@ import { Requests } from "./Requests";
 
 import { useAuth } from "@/lib/auth";
 import { useRequestListStore } from "@/lib/stores/useRequestStore";
-import LoadingScreen from "@/components/blocks/LoadingScreen";
+import LoadingScreen from "@/components/blocks/Loading";
 
 export interface RequestItem {
   id: string;

--- a/src/app/dashboard/requests/[id]/loading/Loading.tsx
+++ b/src/app/dashboard/requests/[id]/loading/Loading.tsx
@@ -1,1 +1,11 @@
-export { default } from "@/components/blocks/Loading";
+"use client";
+
+import ProgressLoading from "@/components/blocks/ProgressLoading";
+
+type Props = {
+  duration: number;
+};
+
+export default function Loading({ duration }: Props) {
+  return <ProgressLoading duration={duration} text="Loading your request..." />;
+}

--- a/src/app/dashboard/requests/[id]/loading/Loading.tsx
+++ b/src/app/dashboard/requests/[id]/loading/Loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "@/components/blocks/LoadingScreen";
+export { default } from "@/components/blocks/Loading";

--- a/src/app/dashboard/requests/[id]/loading/Loading.tsx
+++ b/src/app/dashboard/requests/[id]/loading/Loading.tsx
@@ -6,6 +6,6 @@ type Props = {
   duration: number;
 };
 
-export default function Loading({ duration }: Props) {
-  return <ProgressLoading duration={duration} text="Loading your request..." />;
+export default function Loading({}: Props) {
+  return <ProgressLoading />;
 }

--- a/src/app/dashboard/requests/[id]/loading/Loading.tsx
+++ b/src/app/dashboard/requests/[id]/loading/Loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/components/blocks/LoadingScreen";

--- a/src/app/dashboard/requests/[id]/loading/Loading.tsx
+++ b/src/app/dashboard/requests/[id]/loading/Loading.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import ProgressLoading from "@/components/blocks/ProgressLoading";
+import OrbitalRings from "@/components/blocks/OrbitalRings";
 
 type Props = {
   duration: number;
 };
 
 export default function Loading({}: Props) {
-  return <ProgressLoading />;
+  return <OrbitalRings />;
 }

--- a/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
+++ b/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
@@ -12,6 +12,7 @@ type Props = {
 
 export default function LoadingClient({ requestId, mode, date }: Props) {
   const router = useRouter();
+  const duration = 10000; // single source of truth (10 seconds)
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -20,10 +21,10 @@ export default function LoadingClient({ requestId, mode, date }: Props) {
           date ? `&date=${date}` : ""
         }`
       );
-    }, 10000); // 10 seconds
+    }, duration);
 
     return () => clearTimeout(timer);
-  }, [router, requestId, mode, date]);
+  }, [router, requestId, mode, date, duration]);
 
-  return <Loading />;
+  return <Loading duration={duration} />;
 }

--- a/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
+++ b/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
@@ -20,7 +20,7 @@ export default function LoadingClient({ requestId, mode, date }: Props) {
           date ? `&date=${date}` : ""
         }`
       );
-    }, 20000); // 20 seconds
+    }, 10000); // 10 seconds
 
     return () => clearTimeout(timer);
   }, [router, requestId, mode, date]);

--- a/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
+++ b/src/app/dashboard/requests/[id]/loading/LoadingClient.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Loading from "./Loading";
+
+type Props = {
+  requestId: string;
+  mode: "create" | "edit" | "editDraft";
+  date?: string;
+};
+
+export default function LoadingClient({ requestId, mode, date }: Props) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push(
+        `/dashboard/requests/${requestId}/questions?mode=${mode}${
+          date ? `&date=${date}` : ""
+        }`
+      );
+    }, 20000); // 20 seconds
+
+    return () => clearTimeout(timer);
+  }, [router, requestId, mode, date]);
+
+  return <Loading />;
+}

--- a/src/app/dashboard/requests/[id]/loading/page.tsx
+++ b/src/app/dashboard/requests/[id]/loading/page.tsx
@@ -1,0 +1,44 @@
+import LoadingClient from "./LoadingClient";
+
+interface LoadingPageProps {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function LoadingPage({
+  params,
+  searchParams,
+}: LoadingPageProps) {
+  const { id } = await params;
+  const search = await searchParams;
+
+  if (!id) {
+    return <div className="p-6 text-center">⚠️ Invalid request ID</div>;
+  }
+
+  // Parse optional date
+  const rawDate = search?.date;
+  const date =
+    typeof rawDate === "string"
+      ? rawDate
+      : Array.isArray(rawDate) && rawDate.length > 0
+      ? rawDate[0]
+      : undefined;
+
+  // Parse mode
+  const modeParam = search?.mode;
+  const mode =
+    (typeof modeParam === "string"
+      ? modeParam
+      : Array.isArray(modeParam)
+      ? modeParam[0]
+      : null) ?? "create";
+
+  return (
+    <LoadingClient
+      requestId={id}
+      mode={mode as "create" | "edit" | "editDraft"}
+      date={date}
+    />
+  );
+}

--- a/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
+++ b/src/app/dashboard/requests/[id]/setup/SetupClient.tsx
@@ -123,7 +123,7 @@ export default function SetupClient({
     });
 
     router.push(
-      `/dashboard/requests/${requestId}/questions?mode=${mode}${dateParamWithAmp}`
+      `/dashboard/requests/${requestId}/loading?mode=${mode}${dateParamWithAmp}`
     );
   };
 

--- a/src/components/blocks/Loading.tsx
+++ b/src/components/blocks/Loading.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-export default function LoadingScreen() {
+export default function Loading() {
   return (
     <div className="flex items-center justify-center h-screen w-screen bg-muted">
       <div className="animate-spin rounded-full h-10 w-10 border-4 border-gray-300 border-t-gray-500"></div>

--- a/src/components/blocks/OrbitalRings.tsx
+++ b/src/components/blocks/OrbitalRings.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import Image from "next/image";
 
-export default function OrbitalRingsAligned() {
+export default function OrbitalRings() {
   // Explicit class strings so Tailwind won’t purge them.
   const rings = [
     {

--- a/src/components/blocks/OrbitalRings.tsx
+++ b/src/components/blocks/OrbitalRings.tsx
@@ -113,7 +113,7 @@ export default function OrbitalRings() {
               style={{ animationDelay: r.delay }}
             >
               <div
-                className={`absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full border ${
+                className={`absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-2.5 h-2.5 bg-white rounded-full border ${
                   r.dotBorder ?? ""
                 } shadow-none`}
               />
@@ -126,8 +126,8 @@ export default function OrbitalRings() {
           <Image
             src="/images/logo.png"
             alt="Logo"
-            width={50}
-            height={50}
+            width={55}
+            height={55}
             className="pointer-events-none select-none"
           />
         </div>

--- a/src/components/blocks/ProgressLoading.tsx
+++ b/src/components/blocks/ProgressLoading.tsx
@@ -1,38 +1,136 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { Progress } from "@/components/ui/progress";
+import React from "react";
+import Image from "next/image";
 
-type Props = {
-  duration: number; // milliseconds
-  text: string; // loading message
-};
+export default function OrbitalRingsAligned() {
+  // Explicit class strings so Tailwind won’t purge them.
+  const rings = [
+    {
+      sizeClass: "w-32 h-32",
+      borderClass: "border-gray-300/80",
+      delay: "0s",
+      spin: 40,
+      dotBorder: "border-gray-300/80",
+    },
+    {
+      sizeClass: "w-48 h-48",
+      borderClass: "border-gray-300/60",
+      delay: "0.2s",
+    },
+    {
+      sizeClass: "w-64 h-64",
+      borderClass: "border-gray-300/40",
+      delay: "0.4s",
+      spin: 40,
+      dotBorder: "border-gray-300/40",
+    },
+    {
+      sizeClass: "w-80 h-80",
+      borderClass: "border-gray-300/20",
+      delay: "0.6s",
+    },
+    {
+      sizeClass: "w-96 h-96",
+      borderClass: "border-gray-300/10",
+      delay: "0.8s",
+      spin: 40,
+      dotBorder: "border-gray-300/10",
+    },
+  ];
 
-export default function ProgressLoading({ duration, text }: Props) {
-  const [progress, setProgress] = useState(0);
+  const spinningRings = rings.filter((r) => r.spin);
 
-  useEffect(() => {
-    const steps = 100;
-    const intervalTime = duration / steps; // evenly spread increments
-    let count = 0;
-
-    const interval = setInterval(() => {
-      count++;
-      setProgress((count / steps) * 100);
-
-      if (count >= steps) {
-        clearInterval(interval);
-      }
-    }, intervalTime);
-
-    return () => clearInterval(interval);
-  }, [duration]);
+  // Generate CSS keyframes once (not inside JSX map)
+  const keyframes = spinningRings
+    .map((r, i) => {
+      const startAngle = (360 / spinningRings.length) * i;
+      return `
+        @keyframes spin-${i} {
+          from { transform: rotate(${startAngle}deg); }
+          to { transform: rotate(${startAngle + 360}deg); }
+        }
+      `;
+    })
+    .join("\n");
 
   return (
-    <div className="flex items-center justify-center h-screen w-screen bg-muted">
-      <div className="flex flex-col items-center gap-6 w-80">
-        <p className="text-lg font-medium text-muted-foreground">{text}</p>
-        <Progress value={progress} className="w-full h-2" />
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="relative flex items-center justify-center w-96 h-96">
+        {/* Global styles */}
+        <style jsx global>{`
+          @keyframes ripple {
+            0% {
+              transform: scale(1);
+              opacity: 1;
+            }
+            50% {
+              transform: scale(1.15);
+              opacity: 0.6;
+            }
+            100% {
+              transform: scale(1);
+              opacity: 1;
+            }
+          }
+          @keyframes rippleScale {
+            0% {
+              transform: scale(1);
+            }
+            50% {
+              transform: scale(1.15);
+            }
+            100% {
+              transform: scale(1);
+            }
+          }
+          ${keyframes}
+        `}</style>
+
+        {/* Concentric rings */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          {rings.map((r, i) => (
+            <div
+              key={`ring-${i}`}
+              className={`absolute ${r.sizeClass} rounded-full border ${r.borderClass} animate-[ripple_3s_ease-out_infinite] origin-center`}
+              style={{ animationDelay: r.delay }}
+            />
+          ))}
+        </div>
+
+        {/* Orbiting dots */}
+        {spinningRings.map((r, i) => (
+          <div
+            key={`orbit-${i}`}
+            className="absolute inset-0 flex items-center justify-center"
+            style={{
+              animation: `spin-${i} ${r.spin}s linear infinite`,
+            }}
+          >
+            {/* This container scales with the ring but never fades */}
+            <div
+              className={`absolute ${r.sizeClass} animate-[rippleScale_3s_ease-out_infinite] origin-center`}
+              style={{ animationDelay: r.delay }}
+            >
+              <div
+                className={`absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full border ${
+                  r.dotBorder ?? ""
+                } shadow-none`}
+              />
+            </div>
+          </div>
+        ))}
+
+        {/* Static center logo */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Image
+            src="/images/logo.png"
+            alt="Logo"
+            width={50}
+            height={50}
+            className="pointer-events-none select-none"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/blocks/ProgressLoading.tsx
+++ b/src/components/blocks/ProgressLoading.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Progress } from "@/components/ui/progress";
+
+type Props = {
+  duration: number; // milliseconds
+  text: string; // loading message
+};
+
+export default function ProgressLoading({ duration, text }: Props) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const steps = 100;
+    const intervalTime = duration / steps; // evenly spread increments
+    let count = 0;
+
+    const interval = setInterval(() => {
+      count++;
+      setProgress((count / steps) * 100);
+
+      if (count >= steps) {
+        clearInterval(interval);
+      }
+    }, intervalTime);
+
+    return () => clearInterval(interval);
+  }, [duration]);
+
+  return (
+    <div className="flex items-center justify-center h-screen w-screen bg-muted">
+      <div className="flex flex-col items-center gap-6 w-80">
+        <p className="text-lg font-medium text-muted-foreground">{text}</p>
+        <Progress value={progress} className="w-full h-2" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }


### PR DESCRIPTION
There's now a loading screen between the setup screen and the questions
This screen has a new custom animation
It signals to users that we're processing what they types into setup
(or that the future API is processing it)

The routing is set up so it goes from setup -> loading -> questions
AKA there's now a new loading page
This will let us use this loading page when we call the API

The duration of the animation is hardcoded in the animation component
Presumably, we'll need to change that when hooking up the API

There's no text telling users what's going on during the animation
Presumably, we'll want to add that at some point

The animation component itself is a bit dirty and hacky
Presumably, we'll want to clean it up at some point