### PR TITLE
Link new fields to db

### DIFF
--- a/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
+++ b/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
@@ -45,8 +45,8 @@ export default function Confirm({
           ],
         })}
       // Main
-      title="Edit what we understood"
-      subtitle="This us a summary of what we understood from your request. But we might have misunderstood some of the details"
+      title="Did we understand correctly?"
+      subtitle="This us a summary of what we understood from your request. Make edits if misunderstood some of the details"
       // Footer (two buttons, required)
       primaryButtonText="Done"
       onPrimaryAction={onSubmit}

--- a/src/app/dashboard/requests/[id]/prompt/Prompt.tsx
+++ b/src/app/dashboard/requests/[id]/prompt/Prompt.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-
 import { Textarea } from "@/components/ui/textarea";
 import SetupLayout from "@/components/layouts/SetupLayout";
 import {
@@ -16,8 +14,10 @@ const CUSTOMERS = ["Acme Corp", "Globex", "Initech", "Soylent", "Umbrella"];
 
 interface PromptProps {
   prompt: string;
-  errors: { prompt?: string };
+  customer: string;
+  errors: { prompt?: string; customer?: string };
   setPrompt: (val: string) => void;
+  setCustomer: (val: string) => void;
   onSubmit: () => void | Promise<void>;
   onCancel: () => void | Promise<void>;
   onHome: () => void | Promise<void>;
@@ -29,8 +29,10 @@ interface PromptProps {
 
 export default function Prompt({
   prompt,
+  customer,
   errors,
   setPrompt,
+  setCustomer,
   onSubmit,
   onCancel,
   onHome,
@@ -39,8 +41,6 @@ export default function Prompt({
   setStatus,
   mode,
 }: PromptProps) {
-  const [selectedCustomer, setSelectedCustomer] = useState<string>("");
-
   return (
     <SetupLayout
       // Sidebar
@@ -83,9 +83,13 @@ export default function Prompt({
         )}
       </div>
 
-      <Select onValueChange={(val) => setSelectedCustomer(val)}>
+      <Select value={customer} onValueChange={setCustomer}>
         <SelectTrigger className="mt-4 w-full border border-grey-50 rounded-xl">
-          <SelectValue placeholder="Which customer is this data for?" />
+          <SelectValue placeholder="Which customer is this data for?">
+            {customer ? (
+              <span className="truncate">Customer: {customer}</span>
+            ) : null}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {CUSTOMERS.map((cust) => (
@@ -95,6 +99,9 @@ export default function Prompt({
           ))}
         </SelectContent>
       </Select>
+      {errors.customer && (
+        <p className="text-red-500 text-sm mt-1">{errors.customer}</p>
+      )}
     </SetupLayout>
   );
 }

--- a/src/app/dashboard/requests/[id]/prompt/PromptClient.tsx
+++ b/src/app/dashboard/requests/[id]/prompt/PromptClient.tsx
@@ -90,8 +90,8 @@ export default function PromptClient({ requestId, mode }: PromptClientProps) {
       customer: customer,
     });
 
-    // 👉 Now go to Questions step
-    router.push(`/dashboard/requests/${requestId}/questions?mode=${mode}`);
+    // 👉 Now go to Schedule step
+    router.push(`/dashboard/requests/${requestId}/schedule?mode=${mode}`);
   };
 
   const handleCancel = async (): Promise<void> => {

--- a/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
@@ -29,7 +29,7 @@ const REPEAT = [
   "Every quarter",
 ];
 
-interface QuestionsProps {
+interface ScheduleProps {
   scheduledDate: Date | null;
   setScheduledDate: (d: Date | null) => void;
   errors: { scheduledDate?: string };
@@ -40,7 +40,7 @@ interface QuestionsProps {
   mode: "create" | "edit" | "editDraft";
 }
 
-export default function Questions({
+export default function Schedule({
   scheduledDate,
   setScheduledDate,
   errors,
@@ -48,7 +48,7 @@ export default function Questions({
   onBack,
   onHome,
   minSelectableDate,
-}: QuestionsProps) {
+}: ScheduleProps) {
   const [selectedCustomer, setSelectedCustomer] = useState<string>("");
 
   return (

--- a/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
@@ -38,6 +38,9 @@ interface ScheduleProps {
   onHome: () => void;
   minSelectableDate: Date;
   mode: "create" | "edit" | "editDraft";
+  status?: "draft" | "active";
+  setStatus?: (val: "draft" | "active") => void;
+  onDelete?: () => void;
 }
 
 export default function Schedule({
@@ -50,6 +53,10 @@ export default function Schedule({
   onBack,
   onHome,
   minSelectableDate,
+  mode,
+  status,
+  setStatus,
+  onDelete,
 }: ScheduleProps) {
   return (
     <SetupLayout
@@ -62,6 +69,18 @@ export default function Schedule({
       onPrimaryAction={onSubmit}
       secondaryButtonText="Back"
       onSecondaryAction={onBack}
+      {...(mode !== "create" &&
+        setStatus &&
+        onDelete && {
+          sidebarActionText: "Delete request",
+          onSidebarAction: onDelete,
+          toggleValue: status,
+          onToggleChange: (val) => void setStatus(val as "draft" | "active"),
+          toggleOptions: [
+            { value: "draft", label: "Draft" },
+            { value: "active", label: "Active" },
+          ],
+        })}
     >
       <div>
         <Label htmlFor="scheduledDate" className="mb-3 block">

--- a/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,6 +30,8 @@ const REPEAT = [
 interface ScheduleProps {
   scheduledDate: Date | null;
   setScheduledDate: (d: Date | null) => void;
+  repeat: string;
+  setRepeat: (val: string) => void;
   errors: { scheduledDate?: string };
   onSubmit: () => void;
   onBack: () => void;
@@ -43,14 +43,14 @@ interface ScheduleProps {
 export default function Schedule({
   scheduledDate,
   setScheduledDate,
+  repeat,
+  setRepeat,
   errors,
   onSubmit,
   onBack,
   onHome,
   minSelectableDate,
 }: ScheduleProps) {
-  const [selectedCustomer, setSelectedCustomer] = useState<string>("");
-
   return (
     <SetupLayout
       sidebarBackText="Back to requests"
@@ -88,20 +88,21 @@ export default function Schedule({
         )}
       </div>
 
-      <Label htmlFor="scheduledDate" className="mt-6 mb-3 block">
+      <Label htmlFor="repeat" className="mt-6 mb-3 block">
         Should this repeat?
       </Label>
-      <Select
-        onValueChange={(val) => setSelectedCustomer(val)}
-        defaultValue={REPEAT[0]} // 👈 set first option as default
-      >
+      <Select value={repeat} onValueChange={setRepeat}>
         <SelectTrigger className="mt-4 w-full border border-grey-50 rounded-xl">
-          <SelectValue /> {/* no placeholder here */}
+          <SelectValue>
+            {repeat ? (
+              <span className="truncate">Repeats: {repeat}</span>
+            ) : null}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {REPEAT.map((cust) => (
-            <SelectItem key={cust} value={cust}>
-              {cust}
+          {REPEAT.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
@@ -57,7 +57,7 @@ export default function Schedule({
       onSidebarBack={onHome}
       sidebarTitle="Schedule your data request"
       title="Schedule your request"
-      subtitle="When do you need the data and is this request recurring?"
+      subtitle="When do you need the data and should this request repeat?"
       primaryButtonText="Next"
       onPrimaryAction={onSubmit}
       secondaryButtonText="Back"
@@ -89,7 +89,7 @@ export default function Schedule({
       </div>
 
       <Label htmlFor="scheduledDate" className="mt-6 mb-3 block">
-        Is this recurring?
+        Should this repeat?
       </Label>
       <Select
         onValueChange={(val) => setSelectedCustomer(val)}

--- a/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
@@ -29,6 +29,8 @@ export default function ScheduleClient({
   const { requests, loadOne, updateActive } = useRequestListStore();
 
   const [scheduledDate, setScheduledDate] = useState<Date | null>(null);
+  const [repeat, setRepeat] = useState<string>("Does not repeat");
+
   const [errors, setErrors] = useState<{ scheduledDate?: string }>({});
   const minSelectable = useMemo(() => minSelectableDate(2), []);
 
@@ -46,16 +48,17 @@ export default function ScheduleClient({
   useEffect(() => {
     const existing = requests[requestId];
     if (existing?.scheduledDate) setScheduledDate(existing.scheduledDate);
+    if (existing?.repeat) setRepeat(existing.repeat);
   }, [requests, requestId]);
 
   // auto-save
   useEffect(() => {
     if (!user) return;
     const timeout = setTimeout(() => {
-      updateActive(user.uid, requestId, { scheduledDate });
+      updateActive(user.uid, requestId, { scheduledDate, repeat });
     }, 800);
     return () => clearTimeout(timeout);
-  }, [user, requestId, scheduledDate, updateActive]);
+  }, [user, requestId, scheduledDate, repeat, updateActive]);
 
   const validate = () => {
     if (!scheduledDate)
@@ -74,7 +77,7 @@ export default function ScheduleClient({
   const handleSubmit = async () => {
     if (!validate()) return;
     if (!user) return;
-    await updateActive(user.uid, requestId, { scheduledDate });
+    await updateActive(user.uid, requestId, { scheduledDate, repeat });
     router.push(
       `/dashboard/requests/${requestId}/loading?mode=${mode}&date=${toDateKey(
         scheduledDate!
@@ -98,6 +101,8 @@ export default function ScheduleClient({
     <ScheduleUI
       scheduledDate={scheduledDate}
       setScheduledDate={setScheduledDate}
+      repeat={repeat}
+      setRepeat={setRepeat}
       errors={errors}
       onSubmit={handleSubmit}
       onBack={handleBack}

--- a/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
@@ -11,19 +11,19 @@ import {
 } from "@/lib/requestDates";
 import { useAuth } from "@/lib/auth";
 import { useRequestListStore } from "@/lib/stores/useRequestStore";
-import QuestionsUI from "./Questions";
+import ScheduleUI from "./Schedule";
 
-interface QuestionsClientProps {
+interface ScheduleClientProps {
   requestId: string;
   prefillDate?: string;
   mode: "create" | "edit" | "editDraft";
 }
 
-export default function QuestionsClient({
+export default function ScheduleClient({
   requestId,
   prefillDate,
   mode,
-}: QuestionsClientProps) {
+}: ScheduleClientProps) {
   const router = useRouter();
   const { user } = useAuth();
   const { requests, loadOne, updateActive } = useRequestListStore();
@@ -95,7 +95,7 @@ export default function QuestionsClient({
   };
 
   return (
-    <QuestionsUI
+    <ScheduleUI
       scheduledDate={scheduledDate}
       setScheduledDate={setScheduledDate}
       errors={errors}

--- a/src/app/dashboard/requests/[id]/schedule/page.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/page.tsx
@@ -1,14 +1,14 @@
-import QuestionsClient from "./QuestionsClient";
+import ScheduleClient from "./ScheduleClient";
 
-interface QuestionsPageProps {
+interface SchedulePageProps {
   params: Promise<{ id: string }>;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export default async function QuestionsPage({
+export default async function SchedulePage({
   params,
   searchParams,
-}: QuestionsPageProps) {
+}: SchedulePageProps) {
   const { id } = await params;
   const search = await searchParams;
 
@@ -32,7 +32,7 @@ export default async function QuestionsPage({
       : null) ?? "create";
 
   return (
-    <QuestionsClient
+    <ScheduleClient
       requestId={id}
       prefillDate={prefillDate}
       mode={mode as "create" | "edit" | "editDraft"}

--- a/src/lib/models/request-admin.ts
+++ b/src/lib/models/request-admin.ts
@@ -21,6 +21,8 @@ type FirestoreRequestData = {
   updatedAt?: Timestamp;
   submittedAt?: Timestamp;
   ephemeral?: boolean;
+  customer?: string;
+  repeat?: string;
 };
 
 export const requestReadConverterAdmin: FirestoreDataConverter<Request> = {
@@ -46,6 +48,8 @@ export const requestReadConverterAdmin: FirestoreDataConverter<Request> = {
       updatedAt: d.updatedAt ? d.updatedAt.toDate() : null,
       submittedAt: d.submittedAt ? d.submittedAt.toDate() : null,
       ephemeral: d.ephemeral ?? false,
+      customer: d.customer ?? "",
+      repeat: d.repeat ?? "Does not repeat",
     };
   },
 };

--- a/src/lib/models/request-client.ts
+++ b/src/lib/models/request-client.ts
@@ -21,6 +21,8 @@ type FirestoreRequestData = {
   updatedAt?: Timestamp;
   submittedAt?: Timestamp;
   ephemeral?: boolean;
+  customer?: string;
+  repeat?: string;
 };
 
 export const requestReadConverterClient: FirestoreDataConverter<Request> = {
@@ -46,6 +48,8 @@ export const requestReadConverterClient: FirestoreDataConverter<Request> = {
       updatedAt: d.updatedAt ? d.updatedAt.toDate() : null,
       submittedAt: d.submittedAt ? d.submittedAt.toDate() : null,
       ephemeral: d.ephemeral ?? false,
+      customer: d.customer ?? "",
+      repeat: d.repeat ?? "Does not repeat",
     };
   },
 };

--- a/src/lib/models/request-types.ts
+++ b/src/lib/models/request-types.ts
@@ -8,9 +8,14 @@ export interface Request {
   updatedAt: Date | null;
   submittedAt?: Date | null;
   ephemeral?: boolean;
+  customer?: string;
+  repeat?: string;
 }
 
 // Shape for partial updates
 export type RequestPatch = Partial<
-  Pick<Request, "prompt" | "summary" | "scheduledDate" | "status">
+  Pick<
+    Request,
+    "prompt" | "summary" | "scheduledDate" | "status" | "customer" | "repeat"
+  >
 >;

--- a/src/lib/services/requestService-admin.ts
+++ b/src/lib/services/requestService-admin.ts
@@ -18,6 +18,8 @@ interface WriteRequest {
   createdAt: FieldValue;
   updatedAt: FieldValue;
   submittedAt: FieldValue | null;
+  customer?: string;
+  repeat?: string;
 }
 
 interface WriteUpdate {
@@ -27,6 +29,8 @@ interface WriteUpdate {
   status?: "draft" | "active";
   updatedAt?: FieldValue;
   submittedAt?: FieldValue | null;
+  customer?: string;
+  repeat?: string;
   [key: string]: unknown;
 }
 
@@ -67,6 +71,8 @@ export async function createDraft(
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
     submittedAt: null,
+    customer: initialData.customer ?? "",
+    repeat: initialData.repeat ?? "Does not repeat",
   };
 
   // Write raw data
@@ -102,6 +108,8 @@ export async function submitDraft(
       ? serializeScheduledDate(data.scheduledDate)
       : null;
   }
+  if (data.customer !== undefined) update.customer = data.customer;
+  if (data.repeat !== undefined) update.repeat = data.repeat;
 
   await ref.update(update);
 }
@@ -125,6 +133,8 @@ export async function updateActive(
       ? serializeScheduledDate(data.scheduledDate)
       : null;
   }
+  if (data.customer !== undefined) update.customer = data.customer;
+  if (data.repeat !== undefined) update.repeat = data.repeat;
 
   await ref.update(update);
 }

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -30,6 +30,8 @@ interface WriteRequestClient {
   updatedAt: FieldValue;
   submittedAt?: FieldValue;
   ephemeral?: boolean;
+  customer?: string;
+  repeat?: string;
 }
 
 // --- helpers ---
@@ -81,6 +83,8 @@ export async function createDraft(
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     ephemeral: true,
+    customer: data.customer ?? "",
+    repeat: data.repeat ?? "Does not repeat",
   };
   await setDoc(ref, write, { merge: false });
 }
@@ -113,7 +117,9 @@ export async function ensureDraft(uid: string): Promise<string> {
     scheduledDate: null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
-    ephemeral: true, // mark as system scratchpad
+    ephemeral: true,
+    customer: "",
+    repeat: "Does not repeat",
   };
   await setDoc(newRef, write, { merge: false });
   return newRef.id;
@@ -139,6 +145,14 @@ export async function updateActive(
   }
   if ("scheduledDate" in patch) {
     update.scheduledDate = serializeScheduledDate(patch.scheduledDate ?? null);
+  }
+  if ("customer" in patch) {
+    update.customer = patch.customer ?? "";
+    update.ephemeral = false;
+  }
+  if ("repeat" in patch) {
+    update.repeat = patch.repeat ?? "Does not repeat";
+    update.ephemeral = false;
   }
 
   await updateDoc(ref, update);


### PR DESCRIPTION
The new fields which were added to the requests flow
They now write/read to/from Firestore

The repeat selector's options don't reflect the date info
Which makes them hard to understand
For example, it would be clearer to day "every Friday" than every week