### PR TITLE
Tweak request flow

### DIFF
--- a/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
+++ b/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
@@ -60,7 +60,7 @@ export default function Confirm({
           onChange={(e) => setSummary(e.target.value)}
           readOnly={!isEditable}
           className={`mt-1 min-h-80 ${
-            !isEditable ? "bg-gray-100 text-gray-500 cursor-not-allowed" : ""
+            !isEditable ? "bg-gray-100 text-gray-500" : ""
           }`}
         />
 

--- a/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
+++ b/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import SetupLayout from "@/components/layouts/SetupLayout";
+import { Button } from "@/components/ui/button"; // Assuming you have a Button component
 
 interface ConfirmProps {
   summary: string;
@@ -26,13 +28,13 @@ export default function Confirm({
   setStatus,
   mode,
 }: ConfirmProps) {
+  const [isEditable, setIsEditable] = useState(false);
+
   return (
     <SetupLayout
-      // Sidebar
       sidebarBackText="Back to requests"
       onSidebarBack={onHome}
       sidebarTitle="Edit this summary of your request"
-      // Conditional UI elements
       {...(mode !== "create" &&
         setStatus && {
           sidebarActionText: "Delete request",
@@ -44,23 +46,35 @@ export default function Confirm({
             { value: "active", label: "Active" },
           ],
         })}
-      // Main
       title="Did we understand correctly?"
-      subtitle="This us a summary of what we understood from your request. Make edits if misunderstood some of the details"
-      // Footer (two buttons, required)
+      subtitle="This is a summary of what we understood from your request. Click edit if something is wrong."
       primaryButtonText="Done"
       onPrimaryAction={onSubmit}
       secondaryButtonText="Restart"
       onSecondaryAction={onBack}
     >
-      <div>
+      <div className="relative">
         <Textarea
           id="summary"
           value={summary}
           onChange={(e) => setSummary(e.target.value)}
-          grow
-          className="mt-1 min-h-80"
+          readOnly={!isEditable}
+          className={`mt-1 min-h-80 ${
+            !isEditable ? "bg-gray-100 text-gray-500 cursor-not-allowed" : ""
+          }`}
         />
+
+        {!isEditable && (
+          <div className="absolute bottom-2 right-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setIsEditable(true)}
+            >
+              Edit
+            </Button>
+          </div>
+        )}
       </div>
     </SetupLayout>
   );

--- a/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
+++ b/src/app/dashboard/requests/[id]/confirm/Confirm.tsx
@@ -47,7 +47,7 @@ export default function Confirm({
           ],
         })}
       title="Did we understand correctly?"
-      subtitle="This is a summary of what we understood from your request. Click edit if something is wrong."
+      subtitle="This is a summary of what we understood from your request. Click edit if something is wrong"
       primaryButtonText="Done"
       onPrimaryAction={onSubmit}
       secondaryButtonText="Restart"
@@ -59,8 +59,8 @@ export default function Confirm({
           value={summary}
           onChange={(e) => setSummary(e.target.value)}
           readOnly={!isEditable}
-          className={`mt-1 min-h-80 ${
-            !isEditable ? "bg-gray-100 text-gray-500" : ""
+          className={`mt-1 min-h-90 ${
+            !isEditable ? "bg-gray-50 text-gray-400" : ""
           }`}
         />
 

--- a/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/Schedule.tsx
@@ -112,11 +112,7 @@ export default function Schedule({
       </Label>
       <Select value={repeat} onValueChange={setRepeat}>
         <SelectTrigger className="mt-4 w-full border border-grey-50 rounded-xl">
-          <SelectValue>
-            {repeat ? (
-              <span className="truncate">Repeats: {repeat}</span>
-            ) : null}
-          </SelectValue>
+          <SelectValue>{repeat}</SelectValue>
         </SelectTrigger>
         <SelectContent>
           {REPEAT.map((opt) => (

--- a/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
+++ b/src/app/dashboard/requests/[id]/schedule/ScheduleClient.tsx
@@ -52,11 +52,18 @@ export default function ScheduleClient({
     loadOne(user.uid, requestId);
   }, [user, requestId, loadOne]);
 
-  // hydrate scheduledDate + repeat when request loads
+  // hydrate scheduledDate + repeat once when request loads
   useEffect(() => {
     const existing = requests[requestId];
-    if (existing?.scheduledDate) setScheduledDate(existing.scheduledDate);
-    if (existing?.repeat) setRepeat(existing.repeat);
+    if (!existing) return;
+
+    if (scheduledDate === null && existing.scheduledDate) {
+      setScheduledDate(existing.scheduledDate);
+    }
+
+    if (repeat === "Does not repeat" && existing.repeat) {
+      setRepeat(existing.repeat);
+    }
   }, [requests, requestId]);
 
   // derive status from store

--- a/src/lib/services/requestService-client.ts
+++ b/src/lib/services/requestService-client.ts
@@ -150,8 +150,8 @@ export async function updateActive(
     update.customer = patch.customer ?? "";
     update.ephemeral = false;
   }
-  if ("repeat" in patch) {
-    update.repeat = patch.repeat ?? "Does not repeat";
+  if (patch.repeat !== undefined) {
+    update.repeat = patch.repeat;
     update.ephemeral = false;
   }
 


### PR DESCRIPTION
I'm hoping this will be the last tweaking I do before hooking up the API

Biggest change is that the confirm text box now displays as read only
Then users click an "edit" button to edit it
Goal is to make it more explicit to users that they need to edit

There was a bug with the repeat field
It would overwrite the user's input
Now fixed